### PR TITLE
Allow "sub"-like keywords that can be statements or expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,13 @@ that's currently being compiled. The scope can be lexical, packaged, and global.
 
     - expression
 
-        Boolean flag; if true then the perl parser will treat new code as expression,
-        otherwise as a statement
+        String value; if `"statement"`, then the injected code will be parsed as a
+        statement.  If `"expression"`, if will be parsed as an expression.  If
+        `"dynamic"`, then `code` must be a coderef rather than a string, returning
+        a true value to indicate an expression or a false value to indicate a
+        statement.  (For backward compatibility, a false value for `expression` is
+        treated as `"statement"`, and any unrecognized value is treated as
+        `"expression"`.)
 
     - global
 

--- a/lib/Keyword/Pluggable.pm
+++ b/lib/Keyword/Pluggable.pm
@@ -12,16 +12,28 @@ BEGIN {
 	XSLoader::load __PACKAGE__, $VERSION;
 }
 
+my %modes = (
+	'statement'  => MODE_STATEMENT,
+	'expression' => MODE_EXPRESSION,
+	'dynamic'    => MODE_DYNAMIC,
+);
+
 sub define {
 	my %p = @_;
 	my ($kw, $sub, $expression, $global, $package) = @p{qw(keyword code expression global package)};
 	$kw =~ /^\p{XIDS}\p{XIDC}*\z/ or croak "'$kw' doesn't look like an identifier";
 	defined($sub) or croak "'code' is not defined";
+	$expression //= 'statement';
+	my $sub_is_code = (ref($sub) and
+	                   (UNIVERSAL::isa($sub, 'CODE') or
+	                    $sub->isa('CODE')));
+	$sub_is_code or $expression ne 'dynamic' or croak("expression=dynamic requires a coderef");
 
-	my $xsub = (ref($sub) eq 'CODE') ? $sub : 
-		sub { substr ${$_[0]}, 0, 0, $sub };
+	my $xsub = $sub_is_code ? $sub : sub { substr ${$_[0]}, 0, 0, $sub };
 
-	my $entry = [ $xsub, !!$expression ];
+	my $entry = [ $xsub,
+	              ($modes{$expression} //
+	               ($expression? MODE_EXPRESSION: MODE_STATEMENT)) ];
 
 	if ( defined $package) {
 		no strict 'refs';
@@ -125,8 +137,13 @@ if examination and change is needed.
 
 =item expression
 
-Boolean flag; if true then the perl parser will treat new code as expression,
-otherwise as a statement
+String value; if C<"statement">, then the injected code will be parsed as a
+statement.  If C<"expression">, if will be parsed as an expression.  If
+C<"dynamic">, then C<code> must be a coderef rather than a string, returning
+a true value to indicate an expression or a false value to indicate a
+statement.  (For backward compatibility, a false value for C<expression> is
+treated as C<"statement">, and any unrecognized value is treated as
+C<"expression">.)
 
 =item global
 

--- a/t/dyn.t
+++ b/t/dyn.t
@@ -1,0 +1,34 @@
+#!perl
+use warnings FATAL => 'all';
+use strict;
+
+use Test::More tests => 2;
+
+{
+    package Foo;
+
+    use Keyword::Pluggable;
+
+    sub import {
+        Keyword::Pluggable::define
+		keyword        => 'mysub',
+		code           => sub {
+			my $named = ${$_[0]} =~ /^\s*\p{XIDS}\p{XIDC}*/s;
+                        substr ${$_[0]}, 0, 0, "sub";
+			!$named;
+		},
+		expression => 'dynamic',
+	;
+    }
+
+    sub unimport {
+        Keyword::Pluggable::undefine keyword => 'mysub';
+    }
+
+    BEGIN { $INC{"Foo.pm"} = 1; }
+}
+
+use Foo;
+
+is do { mysub blah { 42 } blah() }, 42, "statement";
+is mysub { 42 }->(), 42, "expression";


### PR DESCRIPTION
This feature supports more flexible keywords that can be statements in some cases and expressions in others.